### PR TITLE
third argument (sleep_interval=0.5) runCmd()

### DIFF
--- a/cmp/logme.py
+++ b/cmp/logme.py
@@ -67,7 +67,7 @@ def mkLocalLog( f ):
 
 
 @mkLocalLog
-def runCmd( cmd, log ):
+def runCmd( cmd, log, sleep_interval=0.5 ):
 
     # timestamp for name
     import random
@@ -75,6 +75,8 @@ def runCmd( cmd, log ):
     # create in temporary file
     import tempfile
     fname = op.join(tempfile.gettempdir(), "out_fifo_%s" % str(t))
+    # import time module
+    import time
 
     try:
         os.unlink( fname )
@@ -97,7 +99,10 @@ def runCmd( cmd, log ):
     
         while process.returncode == None:
             # None means process is still running
-    
+
+            # pause for a while
+            time.sleep(sleep_interval)
+
             # need to poll the process once so the returncode
             # gets set (see docs)
             process.poll()

--- a/cmp/stages/tractography/tractography.py
+++ b/cmp/stages/tractography/tractography.py
@@ -80,7 +80,8 @@ def fiber_tracking_dsi():
                             op.join(gconf.get_cmp_tracto_mask_tob0(), 'fsmask_1mm__8bit.nii'),
                             op.join(fibers_path, 'streamline.trk'), param )
     
-    runCmd( dtb_cmd, log )
+    # set third argument to zero, in order to allow fast processing
+    runCmd( dtb_cmd, log, 0.0 )
         
     if not op.exists(op.join(fibers_path, 'streamline.trk')):
         log.error('No streamline.trk created')    
@@ -110,7 +111,8 @@ def fiber_tracking_dsi_old_streamline():
                             gconf.get_dtb_streamline_vecs_file(),
                             op.join(fibers_path, 'streamline'), param )
     
-    runCmd( dtb_cmd, log )
+    # set third argument to zero, in order to allow fast processing
+    runCmd( dtb_cmd, log, 0.0 )
         
     if not op.exists(op.join(fibers_path, 'streamline.trk')):
         log.error('No streamline.trk created')    
@@ -137,7 +139,8 @@ def fiber_tracking_dti():
                             # use the white matter mask after registration!
                             op.join(gconf.get_cmp_tracto_mask_tob0(), 'fsmask_1mm__8bit.nii'),
                             op.join(fibers_path, 'streamline.trk'), param )
-    runCmd( dtb_cmd, log )
+    # set third argument to zero, in order to allow fast processing
+    runCmd( dtb_cmd, log, 0.0 )
         
     if not op.exists(op.join(fibers_path, 'streamline.trk')):
         log.error('No streamline.trk created')    


### PR DESCRIPTION
Function runCmd() in logme.py contains a while-loop which occupies the CPU. In order avoid unnecessary loops, we introduce a default pause of 0.5 seconds. Since some commands are called in fast succession, the execution would be slowed down. Therefore, the sleep interval can be set as third argument of runCmd().
