### PR TITLE
fix epiunwarp missing

### DIFF
--- a/cmp/__init__.py
+++ b/cmp/__init__.py
@@ -13,7 +13,7 @@ import stages.preprocessing.organize as preprocessing
 import stages.converter.dicomconverter as dicomconverter
 
 # EPI UNWARP
-import stages.epiunwarp.epiunwarp as epiunwarp
+#import stages.epiunwarp.epiunwarp as epiunwarp
 # REGISTRATION
 import stages.registration.registration as registration
 


### PR DESCRIPTION
fixes the "No module named epiunwarp.epiunwarp" error
